### PR TITLE
Add separation model sweep to batch evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ Separated sources (`sep_source0.wav`, `sep_source1.wav`) and the selected result
 
 `eval_tse_on_voices.py` mixes each target speaker with uniform babble noise at specified
 signal-to-noise ratios and evaluates the extraction quality.  Results are written to
-`out_eval/results.csv`.
+`out_eval/results.csv` with columns for speaker, separation model, SNR, babble count,
+SI-SDR, and RTF.
 
 Evaluate a single condition:
 
@@ -65,6 +66,12 @@ Sweep over multiple SNRs and babble counts:
 
 ```bash
 python src/eval_tse_on_voices.py --snr_list "-5,0,5" --babble_list "1,2,3"
+```
+
+Sweep over different separation models:
+
+```bash
+python src/eval_tse_on_voices.py --snr_db 0 --num_babble_voices 3 --sep_models "dprnn,convtasnet,demucs"
 ```
 
 ## Repository Layout


### PR DESCRIPTION
## Summary
- allow evaluating multiple separation models in `eval_tse_on_voices.py` via new `--sep_models` argument
- include model names in evaluation results and README example

## Testing
- `python src/eval_tse_on_voices.py --help`
- `python -m py_compile src/eval_tse_on_voices.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb16cabd408330bdd544c229cf6844