### PR TITLE
Create LibriSpeech directory before download

### DIFF
--- a/src/prepare_voices.py
+++ b/src/prepare_voices.py
@@ -53,6 +53,8 @@ def build_voice_bank(args: argparse.Namespace) -> None:
     import torch
     import torchaudio
 
+    Path("data/LibriSpeech").mkdir(parents=True, exist_ok=True)
+
     dataset = torchaudio.datasets.LIBRISPEECH(
         root="data/LibriSpeech", url=args.subset, download=True
     )


### PR DESCRIPTION
## Summary
- ensure `data/LibriSpeech` directory exists before downloading data

## Testing
- `python -m py_compile src/prepare_voices.py`
- `python src/prepare_voices.py --num_speakers 1 --subset test-clean --limit 0.01` (fails: HTTP Error 403: Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68bb41b044808330b04996c469cd2a67