### PR TITLE
Fix WHAM repo names for separation models

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -185,13 +185,13 @@ def main() -> None:
             from asteroid.models import DPRNNTasNet
 
             sep_model = DPRNNTasNet.from_pretrained(
-                "mpariente/DPRNNTasNet_WHAM!_sepclean_16k"
+                "mpariente/DPRNNTasNet_WHAM_sepclean_16k"
             ).to(device)
         elif model_name == "convtasnet":
             from asteroid.models import ConvTasNet
 
             sep_model = ConvTasNet.from_pretrained(
-                "mpariente/ConvTasNet_WHAM!_sepclean_16k"
+                "mpariente/ConvTasNet_WHAM_sepclean_16k"
             ).to(device)
         elif model_name == "demucs":
             from demucs.pretrained import get_model


### PR DESCRIPTION
## Summary
- correct DPRNN and ConvTasNet pretrained repository IDs by removing invalid `!`

## Testing
- ⚠️ `python src/eval_tse_on_voices.py --snr_db 0 --num_babble_voices 1 --sep_models dprnn,convtasnet` *(failed: No CUDA or MPS accelerator available)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5138a62883308658b9bff071fa03