### PR TITLE
Handle missing OpenVINO dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ torchaudio==2.4.0
 asteroid==0.7.0
 nemo_toolkit[asr]==2.4.0
 huggingface_hub
-openvino
+openvino==2024.1.0


### PR DESCRIPTION
## Summary
- Warn when OpenVINO is absent before using Demucs model
- Avoid calling `eval()` on separation models that don't implement it
- Pin OpenVINO to version 2024.1.0 in requirements

## Testing
- `python -m py_compile src/eval_tse_on_voices.py src/tse_select.py`


------
https://chatgpt.com/codex/tasks/task_e_68bb746ae97c833094459a33c4079a46