### PR TITLE
Fix Demucs OpenVINO model download path

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Sweep over different separation models:
 python src/eval_tse_on_voices.py --snr_db 0 --num_babble_voices 3 --sep_models "dprnn,convtasnet,demucs"
 ```
 
+The `demucs` separation model uses the OpenVINO export from the `Intel/demucs-openvino`
+repository. Ensure the `openvino` package is installed and note that the script downloads
+the `htdemucs_v4` variant on first use.
+
 ## Repository Layout
 
 ```

--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -206,9 +206,22 @@ def main() -> None:
                 ) from exc
 
             core = Core()
-            xml_path = hf_hub_download("Intel/demucs-openvino", "openvino_model.xml")
-            bin_path = hf_hub_download("Intel/demucs-openvino", "openvino_model.bin")
-            ov_model = core.read_model(xml_path, bin_path)
+            repo_id = "Intel/demucs-openvino"
+            variant = "htdemucs_v4"
+            local_dir = "models/demucs_openvino"
+            xml_path = hf_hub_download(
+                repo_id=repo_id,
+                filename="htdemucs_fwd.xml",
+                subfolder=variant,
+                local_dir=local_dir,
+            )
+            hf_hub_download(
+                repo_id=repo_id,
+                filename="htdemucs_fwd.bin",
+                subfolder=variant,
+                local_dir=local_dir,
+            )
+            ov_model = core.read_model(xml_path)
             sep_model = core.compile_model(ov_model, "CPU")
         else:
             raise ValueError(f"Unknown separation model: {model_name}")


### PR DESCRIPTION
## Summary
- ensure Demucs OpenVINO model downloads the `htdemucs_v4` variant and colocates XML/BIN files
- document Demucs OpenVINO requirements in README

## Testing
- `python -m py_compile src/eval_tse_on_voices.py`

------
https://chatgpt.com/codex/tasks/task_e_68bb782c22688330a4c6899f8fd95da9