### PR TITLE
Prevent division-by-zero in mix_at_snr with silent noise

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -83,6 +83,8 @@ def mix_at_snr(target, noise, snr_db: float):
     noise = noise[..., :L]
     target_power = target.pow(2).mean()
     noise_power = noise.pow(2).mean()
+    if noise_power == 0:
+        return target
     scale = torch.sqrt(target_power / noise_power) * (10 ** (-snr_db / 20))
     noise = noise * scale
     return target + noise

--- a/src/tse_select.py
+++ b/src/tse_select.py
@@ -27,6 +27,8 @@ def mix_at_snr(target: torch.Tensor, noise: torch.Tensor, snr_db: float) -> torc
     noise = noise[..., :L]
     target_power = target.pow(2).mean()
     noise_power = noise.pow(2).mean()
+    if noise_power == 0:
+        return target
     scale = torch.sqrt(target_power / noise_power) * (10 ** (-snr_db / 20))
     noise = noise * scale
     return target + noise

--- a/tests/test_mix_at_snr.py
+++ b/tests/test_mix_at_snr.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+
+import tse_select
+import eval_tse_on_voices
+
+def _test_mix_fn(mix_fn):
+    target = torch.randn(16000)
+    noise = torch.zeros_like(target)
+    mixed = mix_fn(target, noise, 0.0)
+    assert torch.allclose(mixed, target)
+    assert torch.isfinite(mixed).all()
+
+def test_mix_at_snr_select():
+    _test_mix_fn(tse_select.mix_at_snr)
+
+def test_mix_at_snr_eval():
+    _test_mix_fn(eval_tse_on_voices.mix_at_snr)


### PR DESCRIPTION
## Summary
- Avoid division by zero when mixing signals with silent noise in `mix_at_snr`
- Add tests ensuring zero-noise mixtures stay finite

## Testing
- `pytest tests/test_mix_at_snr.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7dc53c5c83308b41bff7bf19779f