### PR TITLE
Improve babble selection and add tests

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -139,6 +139,38 @@ def compose_babble(wavs: Iterable, length: int):
     return babble
 
 
+def select_babblers(speakers: list, idx: int, num_babble: int):
+    """Select babble speaker directories excluding the current speaker.
+
+    Parameters
+    ----------
+    speakers: list
+        All available speaker directories.
+    idx: int
+        Index of the current target speaker in ``speakers``.
+    num_babble: int
+        Number of babble speakers to select.
+
+    Raises
+    ------
+    ValueError
+        If ``num_babble`` exceeds the number of other speakers.
+
+    Returns
+    -------
+    list
+        List of directories corresponding to babble speakers.
+    """
+
+    other_speakers = [s for i, s in enumerate(speakers) if i != idx]
+    if num_babble > len(other_speakers):
+        raise ValueError(
+            f"Requested {num_babble} babble voices but only "
+            f"{len(other_speakers)} other speakers available"
+        )
+    return other_speakers[:num_babble]
+
+
 def main() -> None:
     args = parse_args()
 
@@ -234,9 +266,7 @@ def main() -> None:
                 target_wav, sr = load_audio(spk_dir / "target.wav", sr)
 
                 # Select babble speakers deterministically
-                babbler_dirs = [
-                    speakers[(idx + 1 + j) % len(speakers)] for j in range(num_babble)
-                ]
+                babbler_dirs = select_babblers(speakers, idx, num_babble)
                 babble_wavs = [
                     load_audio(b / "target.wav", sr)[0] for b in babbler_dirs
                 ]

--- a/tests/test_select_babblers.py
+++ b/tests/test_select_babblers.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+import pytest
+
+# Ensure the src directory is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1] / 'src'))
+
+from eval_tse_on_voices import select_babblers
+
+
+def test_select_babblers_skips_current_and_no_wrap():
+    speakers = ['a', 'b', 'c']
+    # For idx=1 and num_babble=2, should return remaining speakers in order
+    assert select_babblers(speakers, 1, 2) == ['a', 'c']
+
+
+def test_select_babblers_raises_when_num_babble_exceeds_speakers():
+    speakers = ['a', 'b', 'c']
+    with pytest.raises(ValueError, match='babble voices'):
+        select_babblers(speakers, 0, len(speakers))


### PR DESCRIPTION
## Summary
- ensure babble speakers exclude the target and enforce available count
- add unit tests for babble selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7dcd0cc883308b38aed56e094588