### PR TITLE
Handle missing accelerators by defaulting to CPU

### DIFF
--- a/src/device_utils.py
+++ b/src/device_utils.py
@@ -1,0 +1,15 @@
+import torch
+
+
+def get_device() -> torch.device:
+    """Select appropriate computation device and announce it."""
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+        print(f"Using CUDA device: {torch.cuda.get_device_name(device)}")
+    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        device = torch.device("mps")
+        print("Using MPS device")
+    else:
+        device = torch.device("cpu")
+        print("Using CPU device")
+    return device

--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from typing import Iterable
 
 
+from device_utils import get_device
+
 def parse_args() -> argparse.Namespace:
     """CLI argument parser."""
     parser = argparse.ArgumentParser(
@@ -146,12 +148,7 @@ def main() -> None:
     from nemo.collections.asr.models import EncDecSpeakerLabelModel
 
     # Determine device
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
-    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        device = torch.device("mps")
-    else:
-        raise RuntimeError("No CUDA or MPS accelerator available")
+    device = get_device()
 
     # Determine evaluation combinations
     if args.snr_db is not None and args.num_babble_voices is not None:

--- a/src/tse_select.py
+++ b/src/tse_select.py
@@ -7,6 +7,8 @@ import torch
 import torchaudio
 from pathlib import Path
 
+from device_utils import get_device
+
 
 def load_audio(path: str, target_sr: Optional[int] = None) -> tuple[torch.Tensor, int]:
     """Load audio file, convert to mono, optionally resample."""
@@ -90,15 +92,7 @@ def main():
     args = parser.parse_args()
 
     # Determine device
-    device = None
-    if torch.cuda.is_available():
-        device = torch.device("cuda")
-        print(f"Using CUDA device: {torch.cuda.get_device_name(device)}")
-    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
-        device = torch.device("mps")
-        print("Using MPS device")
-    else:
-        raise RuntimeError("No CUDA or MPS accelerator available")
+    device = get_device()
 
     # Load enrollment/clean target
     target_wav, sr = load_audio(args.target)

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,0 +1,20 @@
+import sys
+from pathlib import Path
+
+import torch
+
+# Ensure src directory is on the path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import device_utils
+
+
+def test_get_device_cpu(monkeypatch, capsys):
+    """When no accelerator is available, CPU should be selected."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
+    if hasattr(torch.backends, "mps"):
+        monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
+    device = device_utils.get_device()
+    captured = capsys.readouterr().out
+    assert device.type == "cpu"
+    assert "CPU" in captured


### PR DESCRIPTION
## Summary
- centralize device selection with a helper that falls back to CPU and prints the chosen accelerator
- use the new device selection in `tse_select.py` and `eval_tse_on_voices.py`
- add a simple test to ensure CPU fallback works

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7dce4b588330a71db7516c4a5c79