### PR TITLE
Enforce valid dataset limit in prepare_voices

### DIFF
--- a/src/prepare_voices.py
+++ b/src/prepare_voices.py
@@ -36,7 +36,7 @@ def parse_args() -> argparse.Namespace:
         default=1.0,
         help=(
             "Fraction of the dataset to use. Useful for quick experiments. "
-            "Value should be between 0 and 1."
+            "Value must be in (0, 1]."
         ),
     )
     parser.add_argument(
@@ -45,7 +45,10 @@ def parse_args() -> argparse.Namespace:
         default="train-clean-100",
         help="LibriSpeech subset to download/use.",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    if not (0 < args.limit <= 1):
+        raise ValueError(f"--limit must be in (0, 1], got {args.limit}")
+    return args
 
 
 def build_voice_bank(args: argparse.Namespace) -> None:

--- a/tests/test_prepare_voices_limit.py
+++ b/tests/test_prepare_voices_limit.py
@@ -1,0 +1,12 @@
+import subprocess
+import sys
+import pytest
+
+@pytest.mark.parametrize("limit", ["0", "-0.5", "1.5"])
+def test_prepare_voices_invalid_limit(limit):
+    result = subprocess.run(
+        [sys.executable, "-m", "src.prepare_voices", "--num_speakers", "1", "--limit", limit],
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert b"--limit must be in (0, 1]" in result.stderr


### PR DESCRIPTION
## Summary
- Require `--limit` to be within (0, 1] and document this constraint
- Add tests ensuring invalid `--limit` values trigger an error

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb7dd0fa6883309d7e0e6dcdb2f16e