### PR TITLE
Remove CPU fallback in device selection

### DIFF
--- a/src/device_utils.py
+++ b/src/device_utils.py
@@ -6,10 +6,9 @@ def get_device() -> torch.device:
     if torch.cuda.is_available():
         device = torch.device("cuda")
         print(f"Using CUDA device: {torch.cuda.get_device_name(device)}")
-    elif hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return device
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
         device = torch.device("mps")
         print("Using MPS device")
-    else:
-        device = torch.device("cpu")
-        print("Using CPU device")
-    return device
+        return device
+    raise RuntimeError("No CUDA or MPS device available")

--- a/tests/test_device_utils.py
+++ b/tests/test_device_utils.py
@@ -1,6 +1,7 @@
 import sys
 from pathlib import Path
 
+import pytest
 import torch
 
 # Ensure src directory is on the path
@@ -9,12 +10,21 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 import device_utils
 
 
-def test_get_device_cpu(monkeypatch, capsys):
-    """When no accelerator is available, CPU should be selected."""
+def test_get_device_cuda(monkeypatch, capsys):
+    """Return CUDA device when available."""
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_name", lambda device=None: "Fake GPU")
+    device = device_utils.get_device()
+    captured = capsys.readouterr().out
+    assert device.type == "cuda"
+    assert "CUDA" in captured
+
+
+def test_get_device_no_accelerator_raises(monkeypatch):
+    """Raise error when no accelerator is present."""
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)
     if hasattr(torch.backends, "mps"):
         monkeypatch.setattr(torch.backends.mps, "is_available", lambda: False)
-    device = device_utils.get_device()
-    captured = capsys.readouterr().out
-    assert device.type == "cpu"
-    assert "CPU" in captured
+    with pytest.raises(RuntimeError):
+        device_utils.get_device()
+


### PR DESCRIPTION
## Summary
- Drop CPU fallback in `get_device` so absence of CUDA/MPS raises error
- Add tests covering CUDA availability and no accelerator scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb80964ef48330afc3c46af587e60e