### PR TITLE
Evaluate single random speaker and archive outputs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ asteroid==0.7.0
 nemo_toolkit[asr]==2.4.0
 huggingface_hub
 openvino==2024.1.0
+matplotlib


### PR DESCRIPTION
## Summary
- Pair SNRs, babbler counts, and models by index for evaluation runs
- Load each requested separation model lazily and reuse across runs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8190047c83308257b098550337b2