### PR TITLE
Return Demucs outputs at original sample rate and length

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -136,6 +136,9 @@ def demucs_openvino_separate(sep_model, wav, sr):
     import torch
     import torchaudio
 
+    orig_sr = sr
+    orig_len = wav.shape[-1]
+
     target_sr = 44100
     if sr != target_sr:
         wav = torchaudio.functional.resample(wav, sr, target_sr)
@@ -191,6 +194,11 @@ def demucs_openvino_separate(sep_model, wav, sr):
         window=window,
         length=seg_length,
     )
+
+    est = est[..., : int(orig_len * target_sr / orig_sr)]
+    if orig_sr != target_sr:
+        est = torchaudio.functional.resample(est, target_sr, orig_sr)
+    est = est[..., :orig_len]
 
     return est
 


### PR DESCRIPTION
## Summary
- Keep track of input audio's original sample rate and length in Demucs OpenVINO separation
- Crop ISTFT output to match the resampled input and resample back to the original rate with final length

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc48f4357083309381e40fa3a869b2