### PR TITLE
Ensure SI-SDR uses common length

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -109,6 +109,16 @@ def ecapa_embedding(model, wav, device):
 def compute_si_sdr(estimate, reference) -> float:
     """Compute SI-SDR between estimate and reference."""
     import torch
+    import warnings
+
+    if estimate.shape[-1] != reference.shape[-1]:
+        min_len = min(estimate.shape[-1], reference.shape[-1])
+        warnings.warn(
+            f"Trimming inputs for SI-SDR: {estimate.shape[-1]} and {reference.shape[-1]} -> {min_len}",
+            stacklevel=2,
+        )
+        estimate = estimate[..., :min_len]
+        reference = reference[..., :min_len]
 
     def zero_mean(x):
         return x - x.mean()

--- a/src/tse_select.py
+++ b/src/tse_select.py
@@ -68,6 +68,17 @@ def ecapa_embedding(model, wav: torch.Tensor, device: torch.device) -> torch.Ten
 
 def compute_si_sdr(estimate: torch.Tensor, reference: torch.Tensor) -> float:
     """Compute SI-SDR between estimate and reference."""
+    import warnings
+
+    if estimate.shape[-1] != reference.shape[-1]:
+        min_len = min(estimate.shape[-1], reference.shape[-1])
+        warnings.warn(
+            f"Trimming inputs for SI-SDR: {estimate.shape[-1]} and {reference.shape[-1]} -> {min_len}",
+            stacklevel=2,
+        )
+        estimate = estimate[..., :min_len]
+        reference = reference[..., :min_len]
+
     def zero_mean(x):
         return x - x.mean()
 

--- a/tests/test_mixture_length.py
+++ b/tests/test_mixture_length.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import torch
 import torchaudio
+import pytest
 
 # Add src directory to sys.path for importing tse_select
 sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
@@ -36,3 +37,14 @@ def test_mix_long_target_short_noise(tmp_path):
     # compute_si_sdr should operate without size mismatch
     val = compute_si_sdr(loaded_mix.squeeze(0), loaded_tgt.squeeze(0))
     float(val)  # should be convertible to float without error
+
+
+def test_compute_si_sdr_trims_and_warns():
+    est = torch.randn(1000)
+    ref = torch.randn(800)
+
+    with pytest.warns(UserWarning):
+        val = compute_si_sdr(est, ref)
+
+    expected = compute_si_sdr(est[:800], ref)
+    assert torch.isclose(val, expected)


### PR DESCRIPTION
## Summary
- Trim estimate/reference tensors to their shortest length before computing SI-SDR
- Warn when trimming occurs to surface mismatched inputs
- Test that compute_si_sdr handles mismatched lengths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc48f54c888330be13cc06f1d085c5