### PR TITLE
Add MUSAN noise mixing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,19 @@ python src/tse_select.py --target path/to/clean.wav --noise path/to/noise.wav \
 Separated sources (`sep_source0.wav`, `sep_source1.wav`) and the selected result
 (`tse_result.wav`) are written alongside the target file.
 
+To test robustness to non-speech noise, provide a path to the [MUSAN dataset](https://www.openslr.org/17)
+and optionally choose a category such as `noise` or `music`:
+
+```bash
+python src/tse_select.py --target path/to/clean.wav \
+       --musan_dir /path/to/musan --musan_category music --snr_db 5
+```
+
 ## Batch Evaluation of Target Speaker Extraction
 
-`eval_tse_on_voices.py` mixes each target speaker with uniform babble noise at
-specified signal-to-noise ratios and evaluates the extraction quality. Each
+`eval_tse_on_voices.py` mixes each target speaker with either uniform babble noise from
+other speakers or a random clip from the MUSAN dataset and then evaluates the extraction
+quality. Each
 invocation creates a timestamped directory under `out_eval` named with the
 current datetime down to milliseconds. A `results.csv` summarising the runs is
 written inside this directory along with one subfolder per run containing the
@@ -69,6 +78,18 @@ Sweep over multiple SNRs and babble counts:
 
 ```bash
 python src/eval_tse_on_voices.py --snr_list "-5,0,5" --babble_list "1,2,3"
+```
+
+Use MUSAN noise instead of babble voices:
+
+```bash
+python src/eval_tse_on_voices.py --snr_db 0 --musan_dir /path/to/musan --musan_category noise
+```
+
+Or sweep SNRs with MUSAN noise:
+
+```bash
+python src/eval_tse_on_voices.py --snr_list "-5,0,5" --musan_dir /path/to/musan
 ```
 
 Sweep over different separation models:

--- a/tests/test_musan_noise.py
+++ b/tests/test_musan_noise.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+import torch
+import torchaudio
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "src"))
+
+from tse_select import sample_musan_noise
+
+
+def test_sample_musan_noise(tmp_path):
+    sr = 16000
+    musan_root = tmp_path / "musan"
+    noise_dir = musan_root / "noise"
+    noise_dir.mkdir(parents=True)
+
+    wav = torch.randn(sr // 2)
+    torchaudio.save(str(noise_dir / "n.wav"), wav.unsqueeze(0), sr)
+
+    out = sample_musan_noise(musan_root, "noise", sr, sr)
+    assert out.shape[-1] == sr
+    assert torch.isfinite(out).all()
+


### PR DESCRIPTION
## Summary
- allow tse_select and batch evaluator to mix background noise sampled from the MUSAN dataset
- expose CLI flags `--musan_dir` and `--musan_category` on `eval_tse_on_voices.py`
- document MUSAN noise usage with examples in the README

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc4e7c58588330bf6715664a56cdcc