### PR TITLE
Add Makefile targets and usage documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+PYTHON ?= python
+
+VOICES_DIR ?= data/voices
+OUT_DIR ?= out_eval
+NUM_SPEAKERS ?= 10
+SUBSET ?= test-clean
+SNR_DB ?= 0
+NUM_BABBLE ?= 3
+SNR_LIST ?= -5,0,5
+BABBLE_LIST ?= 1,2,3
+SEP_MODELS ?= dprnn
+
+.PHONY: prepare eval sweep_snr sweep_babble grid clean
+
+prepare:
+	$(PYTHON) src/prepare_voices.py --out $(VOICES_DIR) --num_speakers $(NUM_SPEAKERS) --subset $(SUBSET)
+
+eval:
+	$(PYTHON) src/eval_tse_on_voices.py --voices_dir $(VOICES_DIR) --out_dir $(OUT_DIR) --snr_db $(SNR_DB) --num_babble_voices $(NUM_BABBLE) --sep_models $(SEP_MODELS)
+
+sweep_snr:
+	$(PYTHON) src/eval_tse_on_voices.py --voices_dir $(VOICES_DIR) --out_dir $(OUT_DIR) --snr_list "$(SNR_LIST)" --num_babble_voices $(NUM_BABBLE) --sep_models $(SEP_MODELS)
+
+sweep_babble:
+	$(PYTHON) src/eval_tse_on_voices.py --voices_dir $(VOICES_DIR) --out_dir $(OUT_DIR) --snr_db $(SNR_DB) --babble_list "$(BABBLE_LIST)" --sep_models $(SEP_MODELS)
+
+grid:
+	$(PYTHON) src/eval_tse_on_voices.py --voices_dir $(VOICES_DIR) --out_dir $(OUT_DIR) --snr_list "$(SNR_LIST)" --babble_list "$(BABBLE_LIST)" --sep_models $(SEP_MODELS)
+
+clean:
+	rm -rf $(OUT_DIR)

--- a/README.md
+++ b/README.md
@@ -102,6 +102,47 @@ The `demucs` separation model uses the OpenVINO export from the `Intel/demucs-op
 repository. Ensure the `openvino` package is installed and note that the script downloads
 the `htdemucs_v4` variant on first use.
 
+## Makefile Targets
+
+Common workflows are wrapped in a Makefile.  Variables may be overridden on the command
+line or via the environment.
+
+Build a voice bank:
+
+```bash
+make prepare NUM_SPEAKERS=10 SUBSET=test-clean
+```
+
+Run a single evaluation:
+
+```bash
+make eval SNR_DB=0 NUM_BABBLE=3
+```
+
+Sweep over SNR values:
+
+```bash
+make sweep_snr SNR_LIST="-5,0,5" NUM_BABBLE=3
+```
+
+Sweep over babble voice counts:
+
+```bash
+make sweep_babble SNR_DB=0 BABBLE_LIST="1,2,3"
+```
+
+Run a full SNR × babble grid:
+
+```bash
+make grid SNR_LIST="-5,0,5" BABBLE_LIST="1,2,3"
+```
+
+Remove evaluation outputs:
+
+```bash
+make clean
+```
+
 ## Repository Layout
 
 ```


### PR DESCRIPTION
## Summary
- add Makefile with targets for voice bank creation, evaluation runs, SNR and babble sweeps, grid search, and cleanup
- document Makefile usage with example invocations in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc55909a188330ae024dc95d7562b9