### PR TITLE
Document available LibriSpeech subsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@ bank with enrollment and target audio for each speaker.
 python src/prepare_voices.py --num_speakers 10 --subset test-clean
 ```
 
+The `--subset` argument accepts any of the official LibriSpeech subsets:
+
+- `dev-clean`
+- `dev-other`
+- `test-clean`
+- `test-other`
+- `train-clean-100`
+- `train-clean-360`
+- `train-other-500`
+
 Resulting structure:
 
 ```


### PR DESCRIPTION
## Summary
- list supported LibriSpeech dataset subsets for the `--subset` option in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc5baa85ec8330810e50b99c600105