### PR TITLE
Validate LibriSpeech subset argument

### DIFF
--- a/src/prepare_voices.py
+++ b/src/prepare_voices.py
@@ -2,6 +2,18 @@ import argparse
 from pathlib import Path
 import random
 
+
+# Valid subset names as expected by torchaudio.datasets.LIBRISPEECH
+LIBRISPEECH_SUBSETS = {
+    "train-clean-100",
+    "train-clean-360",
+    "train-other-500",
+    "dev-clean",
+    "dev-other",
+    "test-clean",
+    "test-other",
+}
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description="Build a local voice bank using the LibriSpeech dataset."
@@ -48,6 +60,11 @@ def parse_args() -> argparse.Namespace:
     args = parser.parse_args()
     if not (0 < args.limit <= 1):
         raise ValueError(f"--limit must be in (0, 1], got {args.limit}")
+    if args.subset not in LIBRISPEECH_SUBSETS:
+        valid = ", ".join(sorted(LIBRISPEECH_SUBSETS))
+        raise ValueError(
+            f"Invalid --subset '{args.subset}'. Valid options: {valid}"
+        )
     return args
 
 

--- a/tests/test_prepare_voices_limit.py
+++ b/tests/test_prepare_voices_limit.py
@@ -10,3 +10,21 @@ def test_prepare_voices_invalid_limit(limit):
     )
     assert result.returncode != 0
     assert b"--limit must be in (0, 1]" in result.stderr
+
+
+@pytest.mark.parametrize("subset", ["train-clean-10", "unknown", "dev-clean-100"])
+def test_prepare_voices_invalid_subset(subset):
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "src.prepare_voices",
+            "--num_speakers",
+            "1",
+            "--subset",
+            subset,
+        ],
+        capture_output=True,
+    )
+    assert result.returncode != 0
+    assert b"Invalid --subset" in result.stderr


### PR DESCRIPTION
## Summary
- ensure `--subset` accepts only known LibriSpeech options
- add tests for invalid subset values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7090a4008330acb455570f1d8d20