### PR TITLE
Default Makefile to python3 and document override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-PYTHON ?= python
+# Default Python interpreter; override with `make PYTHON=/path/to/python ...`
+PYTHON ?= python3
 
 VOICES_DIR ?= data/voices
 OUT_DIR ?= out_eval

--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ the `htdemucs_v4` variant on first use.
 ## Makefile Targets
 
 Common workflows are wrapped in a Makefile.  Variables may be overridden on the command
-line or via the environment.
+line or via the environment.  The Makefile uses `python3` by default; choose a different
+interpreter with the `PYTHON` variable (e.g. `make eval PYTHON=python3.11`).
 
 Build a voice bank:
 


### PR DESCRIPTION
## Summary
- Default Makefile `PYTHON` to `python3` and allow overriding via CLI
- Document interpreter default and override example in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc70e6db448330ba52061ce4491042