### PR TITLE
Fix torchaudio scope error in evaluation script

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -534,7 +534,6 @@ def main() -> None:
         out_dir = timestamp_dir / f"run_{run_idx}"
         out_dir.mkdir(parents=True, exist_ok=True)
 
-        import torchaudio
         torchaudio.save(out_dir / "mixture.wav", mixture.unsqueeze(0), sr)
         torchaudio.save(out_dir / "tse_result.wav", tse_result.unsqueeze(0), sr)
         torchaudio.save(out_dir / "noise.wav", noise.unsqueeze(0), sr)


### PR DESCRIPTION
## Summary
- remove local `torchaudio` import in `eval_tse_on_voices.py` that shadowed the module and caused an `UnboundLocalError`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc731bc0148330b365dab1dd4e0298