### PR TITLE
Add progress feedback to voice preparation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ nemo_toolkit[asr]==2.4.0
 huggingface_hub
 openvino==2024.1.0
 matplotlib
+tqdm


### PR DESCRIPTION
## Summary
- show message when downloading LibriSpeech subset
- add `tqdm` progress bars while collecting utterances and writing speakers
- include `tqdm` in requirements

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc786219708330910e3515871a3f5a