### PR TITLE
Force OpenVINO Demucs inference on GPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,9 @@ python src/eval_tse_on_voices.py --snr_db 0 --num_babble_voices 3 --sep_models "
 ```
 
 The `demucs` separation model uses the OpenVINO export from the `Intel/demucs-openvino`
-repository. Ensure the `openvino` package is installed and note that the script downloads
-the `htdemucs_v4` variant on first use.
+repository. Ensure the `openvino` package is installed **with GPU support**; the scripts
+compile the model for GPU execution and will error if a GPU device is unavailable. The
+`htdemucs_v4` variant is downloaded on first use.
 
 ## Text Evaluation
 

--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -393,8 +393,10 @@ def load_sep_model(model_name: str, device):
             subfolder=variant,
             local_dir=local_dir,
         )
+        if "GPU" not in core.available_devices:
+            raise RuntimeError("OpenVINO GPU device is required but not available")
         ov_model = core.read_model(xml_path)
-        model = core.compile_model(ov_model, "CPU")
+        model = core.compile_model(ov_model, "GPU")
     else:
         raise ValueError(f"Unknown separation model: {model_name}")
 

--- a/src/tse_select.py
+++ b/src/tse_select.py
@@ -271,8 +271,10 @@ def main():
             subfolder=variant,
             local_dir=local_dir,
         )
+        if "GPU" not in core.available_devices:
+            raise RuntimeError("OpenVINO GPU device is required but not available")
         ov_model = core.read_model(xml_path)
-        model = core.compile_model(ov_model, "CPU")
+        model = core.compile_model(ov_model, "GPU")
         start = time.time()
         est_sources = demucs_openvino_separate(model, mixture, sr)
 

--- a/tests/test_openvino_gpu.py
+++ b/tests/test_openvino_gpu.py
@@ -1,0 +1,66 @@
+"""Tests to ensure OpenVINO Demucs runs on GPU."""
+
+from pathlib import Path
+
+import pytest
+import torch
+
+
+def _dummy_download(**kwargs):
+    """Return a dummy path for hf_hub_download calls."""
+    filename = kwargs.get("filename", "model.xml")
+    local_dir = Path(kwargs.get("local_dir", "."))
+    local_dir.mkdir(parents=True, exist_ok=True)
+    path = local_dir / filename
+    path.touch()
+    return path
+
+
+class _DummyCompiledModel:
+    def output(self, idx: int):
+        return idx
+
+
+class _DummyCore:
+    """Minimal OpenVINO Core stub capturing compile target."""
+
+    available_devices = ["GPU"]
+
+    def __init__(self):
+        self.last_device = None
+
+    def read_model(self, *_args, **_kwargs):  # pragma: no cover - trivially exercised
+        return "ov_model"
+
+    def compile_model(self, model, device):  # pragma: no cover - exercised by test
+        self.last_device = device
+        return _DummyCompiledModel()
+
+
+def test_load_sep_model_uses_gpu(monkeypatch):
+    """load_sep_model should compile OpenVINO models on GPU."""
+
+    from eval_tse_on_voices import load_sep_model
+
+    dummy_core = _DummyCore()
+    monkeypatch.setattr("openvino.runtime.Core", lambda: dummy_core)
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", _dummy_download)
+
+    load_sep_model("demucs", torch.device("cpu"))
+    assert dummy_core.last_device == "GPU"
+
+
+def test_load_sep_model_errors_without_gpu(monkeypatch):
+    """load_sep_model should raise when OpenVINO GPU is unavailable."""
+
+    from eval_tse_on_voices import load_sep_model
+
+    class NoGpuCore(_DummyCore):
+        available_devices = ["CPU"]
+
+    monkeypatch.setattr("openvino.runtime.Core", lambda: NoGpuCore())
+    monkeypatch.setattr("huggingface_hub.hf_hub_download", _dummy_download)
+
+    with pytest.raises(RuntimeError):
+        load_sep_model("demucs", torch.device("cpu"))
+


### PR DESCRIPTION
## Summary
- ensure Demucs OpenVINO model compiles only for GPU
- document GPU requirement for Demucs/OpenVINO
- add tests verifying GPU enforcement

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc7e0262108330bb657129ec1cec83