### PR TITLE
Use speech-trained Demucs model

### DIFF
--- a/src/eval_tse_on_voices.py
+++ b/src/eval_tse_on_voices.py
@@ -294,7 +294,7 @@ def load_sep_model(model_name: str, device):
             subprocess.check_call([sys.executable, "-m", "pip", "install", "demucs"])
             from demucs.pretrained import get_model
 
-        model = get_model(name="htdemucs").to(device)
+        model = get_model(name="htdemucs_speech").to(device)
     else:
         raise ValueError(f"Unknown separation model: {model_name}")
 

--- a/src/tse_select.py
+++ b/src/tse_select.py
@@ -255,7 +255,7 @@ def main():
             from demucs.pretrained import get_model
             from demucs.apply import apply_model
 
-        model = get_model(name="htdemucs").to(device)
+        model = get_model(name="htdemucs_speech").to(device)
         model.eval()
         start = time.time()
         with torch.no_grad():


### PR DESCRIPTION
## Summary
- Replace default Demucs checkpoint with `htdemucs_speech` to use speech-trained separation model.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc9662bb308330b7e49055c8877261